### PR TITLE
Link class and show class docstring inside other doc,

### DIFF
--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -134,10 +134,17 @@ character passwords in the server's ``passwords.txt``.
 
 We now describe various core parts of sbws.
 
+.. _relay-prioritization:
+
 3.1 Simple relay prioritization
 -------------------------------
 
 This may be the most complex part of sbws.
+
+:class:`RelayPrioritizer <sbws.lib.relayprioritizer.RelayPrioritizer>`
+
+.. autoclass:: sbws.lib.relayprioritizer.RelayPrioritizer
+  :noindex:
 
 Sbws makes an effort to prioritize measurements of relays that don't have many
 recent results. For example: relays that just joined the Tor network or relays


### PR DESCRIPTION
as an example of cross-referencing, to don't have to write twice in the specs and code the implementation details
No need to merge