### PR TITLE
Modify pytest arguments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands=
 # passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = .[test]
 commands =
-   coverage run --rcfile={toxinidir}/.coveragerc --source=sbws -m pytest -svx {toxinidir}/tests
+   coverage run --rcfile={toxinidir}/.coveragerc --source=sbws -m pytest -s {toxinidir}/tests
 
 
 [testenv:doc]


### PR DESCRIPTION
- Stop coverage command from being so loud
- Keep running after failed unit tests

I made this a PR instead of just merging it myself because I wasn't sure if there was a technical reason for using `-x` and `-v`.

-------

`-x` means stop after the first failure. I think it would be nice to have pytest keep going and figure out all error. What do you think?

`-v` means verbose output. I would rather see a couple lines. And when a test does fail, it still prints out more information about that test.

```
tests/commands/test_stats.py .....                                                                                   
tests/util/test_simpleauth.py ..........FF..                                                                         
tests/util/test_sockio.py ....
```

than a line for every test.

```
tests/commands/test_stats.py::test_stats_uninitted PASSED
tests/commands/test_stats.py::test_stats_initted PASSED
tests/commands/test_stats.py::test_stats_stale_result PASSED
tests/commands/test_stats.py::test_stats_fresh_result PASSED
tests/commands/test_stats.py::test_stats_fresh_results PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_nodata PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_timeout_magic PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_goodmagic PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_timeout_version PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_goodversion PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_nonunicodepassword PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_timeout_password PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_badpassword PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_goodpassword PASSED
tests/util/test_simpleauth.py::test_simpleauth_authclient_cantsend PASSED
tests/util/test_simpleauth.py::test_simpleauth_authserver_timeout PASSED
tests/util/test_simpleauth.py::test_simpleauth_authserver_bad PASSED
tests/util/test_simpleauth.py::test_simpleauth_authserver_good PASSED
tests/util/test_simpleauth.py::test_simpleauth_authserver_badsuccesscode PASSED
tests/util/test_sockio.py::test_sockio_simple PASSED
tests/util/test_sockio.py::test_sockio_empty PASSED
tests/util/test_sockio.py::test_sockio_null PASSED
```

We might have 100 by the time I'm done!