### PR TITLE
Give ResultError subtypes different freshness reduction factors

### DIFF
--- a/sbws/lib/relayprioritizer.py
+++ b/sbws/lib/relayprioritizer.py
@@ -22,10 +22,6 @@ MIN_TO_RETURN = 50
 #
 # Alternatively, we could rewrite best_priority() to not suck so much.
 PERCENT_TO_RETURN = 0.05  # 5%
-# How much we reduce freshness for results that were non-successful. A larger
-# penality reduces freshness more, therefore the relay's priority will be
-# better, therefore we'll measure it again sooner.
-ERROR_PENALTY = 0.5
 
 
 class RelayPrioritizer:
@@ -85,9 +81,13 @@ class RelayPrioritizer:
                     # Reduce the freshness for results containing errors so
                     # that they are not de-prioritized as much. This way, we
                     # will come back to them sooner to try again.
-                    log.debug('Cutting freshness for a %s result for %s',
-                              result.type.value, relay.nickname)
-                    freshness *= (1 - ERROR_PENALTY)
+                    assert result.freshness_reduction_factor >= 0.0
+                    assert result.freshness_reduction_factor <= 1.0
+                    log.debug('Cutting freshness for a %s result by %d%% for '
+                              '%s', result.type.value,
+                              result.freshness_reduction_factor * 100,
+                              relay.nickname)
+                    freshness *= result.freshness_reduction_factor
                 priority += freshness
             relay.priority = priority
         # Sort the relays by their priority, with the smallest (best) priority

--- a/sbws/lib/relayprioritizer.py
+++ b/sbws/lib/relayprioritizer.py
@@ -87,7 +87,7 @@ class RelayPrioritizer:
                               '%s', result.type.value,
                               result.freshness_reduction_factor * 100,
                               relay.nickname)
-                    freshness *= result.freshness_reduction_factor
+                    freshness *= max(1.0-result.freshness_reduction_factor, 0)
                 priority += freshness
             relay.priority = priority
         # Sort the relays by their priority, with the smallest (best) priority

--- a/sbws/lib/resultdump.py
+++ b/sbws/lib/resultdump.py
@@ -233,6 +233,23 @@ class ResultError(Result):
         return _ResultType.Error
 
     @property
+    def freshness_reduction_factor(self):
+        '''
+        When the RelayPrioritizer encounters this Result, how much should it
+        adjust its freshness? (See RelayPrioritizer.best_priority() for more
+        information about "freshness")
+
+        A higher factor makes the freshness lower (making the Result seem
+        older). A lower freshness leads to the relay having better priority,
+        and better priority means it will be measured again sooner.
+
+        The value 0.5 was chosen somewhat arbitrarily, but a few weeks of live
+        network testing verifies that sbws is still able to perform useful
+        measurements in a reasonable amount of time.
+        '''
+        return 0.5
+
+    @property
     def msg(self):
         return self._msg
 
@@ -301,6 +318,19 @@ class ResultErrorAuth(ResultError):
     @property
     def type(self):
         return _ResultType.ErrorAuth
+
+    @property
+    def freshness_reduction_factor(self):
+        '''
+        Override the default ResultError.freshness_reduction_factor because a
+        ResultErrorAuth is most likely not the measured relay's fault, so we
+        shouldn't hurt its priority as much. A higher reduction factor means a
+        Result's effective freshness is reduced more, which makes the relay's
+        priority better.
+
+        The value 0.9 was chosen somewhat arbitrarily.
+        '''
+        return 0.9
 
     @staticmethod
     def from_dict(d):


### PR DESCRIPTION
A failure to measure a relay is not necessarily that relay's fault. Add
(and use) code that allows different ResultError subtypes to reduce a
result's freshness by different amounts. This way, if a bad result was
not likely to be the relay's fault, it won't be penalized very much.

GH: closes #61