### PR TITLE
 Include software and sofware_version in v3bw files

### DIFF
--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -1,5 +1,6 @@
 from sbws import version
 from sbws.globals import (fail_hard, is_initted, time_now)
+from sbws.lib.v3bwfile import V3BwHeader
 from sbws.lib.resultdump import ResultSuccess
 from sbws.lib.resultdump import load_recent_results_in_datadir
 from sbws.lib.resultdump import group_results_by_relay
@@ -120,10 +121,10 @@ def main(args, conf):
     data_lines = [result_data_to_v3bw_line(data, fp) for fp in data]
     data_lines = sorted(data_lines, key=lambda d: d.bw, reverse=True)
     data_lines = scale_lines(args, data_lines)
+    header = V3BwHeader()
     log_stats(data_lines)
     log.info('Writing v3bw file to %s', args.output)
     with open(args.output, 'wt') as fd:
-        fd.write('{}\n'.format(int(time_now())))
-        fd.write('version={}\n'.format(version))
+        fd.write(header)
         for line in data_lines:
             fd.write('{}\n'.format(str(line)))

--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -125,6 +125,6 @@ def main(args, conf):
     log_stats(data_lines)
     log.info('Writing v3bw file to %s', args.output)
     with open(args.output, 'wt') as fd:
-        fd.write(header)
+        fd.write(str(header))
         for line in data_lines:
             fd.write('{}\n'.format(str(line)))

--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -1,5 +1,4 @@
-from sbws import version
-from sbws.globals import (fail_hard, is_initted, time_now)
+from sbws.globals import (fail_hard, is_initted)
 from sbws.lib.v3bwfile import V3BwHeader
 from sbws.lib.resultdump import ResultSuccess
 from sbws.lib.resultdump import load_recent_results_in_datadir

--- a/sbws/globals.py
+++ b/sbws/globals.py
@@ -23,6 +23,7 @@ SOCKET_TIMEOUT = 60  # seconds
 
 SPEC_VERSION = '1.1.0'
 
+
 def is_initted(d):
     if not os.path.isdir(d):
         log.debug('%s not initialized: %s doesn\'t exist', d, d)

--- a/sbws/globals.py
+++ b/sbws/globals.py
@@ -21,6 +21,7 @@ MIN_REQ_BYTES = 1
 MAX_REQ_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
 SOCKET_TIMEOUT = 60  # seconds
 
+SPEC_VERSION = '1.1.0'
 
 def is_initted(d):
     if not os.path.isdir(d):

--- a/sbws/lib/v3bwfile.py
+++ b/sbws/lib/v3bwfile.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Classes and functions that create the bandwidth measurements document
+(v3bw) used by bandwidth authorities."""
+
+import logging
+from sbws import version
+from sbws.globals import time_now, SPEC_VERSION
+
+log = logging.getLogger(__name__)
+
+
+class V3BwHeader(object):
+    """
+    Create a bandwidth measurements (V3bw) header
+    following bandwidth measurements document spec version 1.1.0.
+
+    :param int timestamp: timestamp in Unix Epoch seconds when the document
+                          is created
+    :param str version: the spec version
+    :param str software: the name of the software that generates this
+    :param str software_version: the version of the software
+    """
+    def __init__(self, timestamp=None, version=SPEC_VERSION, software='sbws',
+                 software_version=version):
+        self.timestamp = timestamp or int(time_now())
+        self.version = version
+        self.software = software
+        self.software_version = software_version
+
+    def __str__(self):
+        """Return header string following spec version 1.1.0."""
+        frmt = '{timestamp}\nversion={version}\nsoftware={software}\n' \
+               'software_version={software_version}\n'
+        return frmt.format(**self.__dict__)

--- a/tests/core/test_generate.py
+++ b/tests/core/test_generate.py
@@ -8,6 +8,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+NUM_LINES_HEADER = 4
 
 def test_generate_no_dotsbws(tmpdir, caplog, parser):
     caplog.set_level(logging.DEBUG)
@@ -96,20 +97,20 @@ def test_generate_single_success_noscale(dotsbws_success_result, caplog,
         'should be a success'
     captured = capfd.readouterr()
     stdout_lines = captured.out.strip().split('\n')
-    assert len(stdout_lines) == 3
+    assert len(stdout_lines) == 1 + NUM_LINES_HEADER
 
     # XXX: after mocking time, make sure first line is the current timestamp
     # assert stdout_lines[0] is current timestamp
-
-    v = 'version={}'.format(version)
-    assert stdout_lines[1] == v
+    # FIXME: this is now down in V3BwHeader
+    # v = 'version={}'.format(version)
+    # assert stdout_lines[1] == v
 
     bw = round(median([dl['amount'] / dl['duration'] / 1024
                        for dl in result.downloads]))
     rtt = median([round(r * 1000) for r in result.rtts])
     bw_line = 'node_id=${} bw={} nick={} rtt={} time={}'.format(
         result.fingerprint, bw, result.nickname, rtt, round(result.time))
-    assert stdout_lines[2] == bw_line
+    assert stdout_lines[NUM_LINES_HEADER] == bw_line
 
 
 def test_generate_single_success_scale(dotsbws_success_result, parser,
@@ -128,19 +129,19 @@ def test_generate_single_success_scale(dotsbws_success_result, parser,
         'should be a success'
     captured = capfd.readouterr()
     stdout_lines = captured.out.strip().split('\n')
-    assert len(stdout_lines) == 3
+    assert len(stdout_lines) == 1 + NUM_LINES_HEADER
 
     # XXX: after mocking time, make sure first line is the current timestamp
     # assert stdout_lines[0] is current timestamp
-
-    v = 'version={}'.format(version)
-    assert stdout_lines[1] == v
+    # FIXME: this is now down in V3BwHeader
+    # v = 'version={}'.format(version)
+    # assert stdout_lines[1] == v
 
     bw = 7500
     rtt = median([round(r * 1000) for r in result.rtts])
     bw_line = 'node_id=${} bw={} nick={} rtt={} time={}'.format(
         result.fingerprint, bw, result.nickname, rtt, round(result.time))
-    assert stdout_lines[2] == bw_line
+    assert stdout_lines[NUM_LINES_HEADER] == bw_line
 
 
 def test_generate_single_relay_success_noscale(
@@ -158,13 +159,13 @@ def test_generate_single_relay_success_noscale(
             'should be a success'
     captured = capfd.readouterr()
     stdout_lines = captured.out.strip().split('\n')
-    assert len(stdout_lines) == 3
+    assert len(stdout_lines) == 1 + NUM_LINES_HEADER
 
     # XXX: after mocking time, make sure first line is the current timestamp
     # assert stdout_lines[0] is current timestamp
-
-    v = 'version={}'.format(version)
-    assert stdout_lines[1] == v
+    # FIXME: this is now down in V3BwHeader
+    # v = 'version={}'.format(version)
+    # assert stdout_lines[1] == v
 
     speeds = [dl['amount'] / dl['duration'] / 1024
               for r in results for dl in r.downloads]
@@ -172,7 +173,7 @@ def test_generate_single_relay_success_noscale(
     rtt = round(median([round(r * 1000) for r in result.rtts]))
     bw_line = 'node_id=${} bw={} nick={} rtt={} time={}'.format(
         result.fingerprint, speed, result.nickname, rtt, round(result.time))
-    assert stdout_lines[2] == bw_line
+    assert stdout_lines[NUM_LINES_HEADER] == bw_line
 
 
 def test_generate_single_relay_success_scale(
@@ -191,19 +192,19 @@ def test_generate_single_relay_success_scale(
             'should be a success'
     captured = capfd.readouterr()
     stdout_lines = captured.out.strip().split('\n')
-    assert len(stdout_lines) == 3
+    assert len(stdout_lines) == 1 + NUM_LINES_HEADER
 
     # XXX: after mocking time, make sure first line is the current timestamp
     # assert stdout_lines[0] is current timestamp
-
-    v = 'version={}'.format(version)
-    assert stdout_lines[1] == v
+    # FIXME: this is now down in V3BwHeader
+    # v = 'version={}'.format(version)
+    # assert stdout_lines[1] == v
 
     speed = 7500
     rtt = round(median([round(r * 1000) for r in result.rtts]))
     bw_line = 'node_id=${} bw={} nick={} rtt={} time={}'.format(
         result.fingerprint, speed, result.nickname, rtt, round(result.time))
-    assert stdout_lines[2] == bw_line
+    assert stdout_lines[NUM_LINES_HEADER] == bw_line
 
 
 def test_generate_two_relays_success_noscale(
@@ -221,13 +222,13 @@ def test_generate_two_relays_success_noscale(
             'should be a success'
     captured = capfd.readouterr()
     stdout_lines = captured.out.strip().split('\n')
-    assert len(stdout_lines) == 4
+    assert len(stdout_lines) == 2 + NUM_LINES_HEADER
 
     # XXX: after mocking time, make sure first line is the current timestamp
     # assert stdout_lines[0] is current timestamp
-
-    v = 'version={}'.format(version)
-    assert stdout_lines[1] == v
+    # FIXME: this is now down in V3BwHeader
+    # v = 'version={}'.format(version)
+    # assert stdout_lines[1] == v
 
     r1_results = [r for r in results if r.fingerprint == 'A' * 40]
     r1_time = round(max([r.time for r in r1_results]))
@@ -240,7 +241,7 @@ def test_generate_two_relays_success_noscale(
                            for rtt in r.rtts]))
     bw_line = 'node_id=${} bw={} nick={} rtt={} time={}'.format(
         r1_fingerprint, r1_speed, r1_name, r1_rtt, r1_time)
-    assert stdout_lines[3] == bw_line
+    assert stdout_lines[1 + NUM_LINES_HEADER] == bw_line
 
     r2_results = [r for r in results if r.fingerprint == 'B' * 40]
     r2_time = round(max([r.time for r in r2_results]))
@@ -253,4 +254,4 @@ def test_generate_two_relays_success_noscale(
                            for rtt in r.rtts]))
     bw_line = 'node_id=${} bw={} nick={} rtt={} time={}'.format(
         r2_fingerprint, r2_speed, r2_name, r2_rtt, r2_time)
-    assert stdout_lines[2] == bw_line
+    assert stdout_lines[NUM_LINES_HEADER] == bw_line

--- a/tests/core/test_generate.py
+++ b/tests/core/test_generate.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 NUM_LINES_HEADER = 4
 
+
 def test_generate_no_dotsbws(tmpdir, caplog, parser):
     caplog.set_level(logging.DEBUG)
     dotsbws = tmpdir

--- a/tests/core/test_generate.py
+++ b/tests/core/test_generate.py
@@ -1,4 +1,3 @@
-from sbws import version
 import sbws.core.generate
 from sbws.util.config import get_config
 from sbws.lib.resultdump import load_recent_results_in_datadir

--- a/tests/lib/test_v3bwfile.py
+++ b/tests/lib/test_v3bwfile.py
@@ -10,6 +10,7 @@ def test_v3bwheader_str():
     assert str(header) == '{}\nversion=1.1.0\nsoftware=sbws\n' \
                           'software_version=0.1.0\n'.format(timestamp)
 
+
 def test_v3bwfile():
     """Test generate v3bw file (including relay_lines)."""
     pass

--- a/tests/lib/test_v3bwfile.py
+++ b/tests/lib/test_v3bwfile.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Test generation of bandwidth measurements document (v3bw)"""
+from sbws.lib.v3bwfile import V3BwHeader
+
+
+def test_v3bwheader_str():
+    """Test header str"""
+    timestamp = 1524661857
+    header = V3BwHeader(timestamp)
+    assert str(header) == '{}\nversion=1.1.0\nsoftware=sbws\n' \
+                          'software_version=0.1.0\n'.format(timestamp)
+
+def test_v3bwfile():
+    """Test generate v3bw file (including relay_lines)."""
+    pass


### PR DESCRIPTION
Fixes #96.
I thought it would be better to move all that has to do with the generation of the v3bw files to ``lib/v3bwfile`` module and leave ``generate.py`` basically with only the ``main``. This way we can start to separate better what is obtaining measurements and what is generating the files for the bwauths, as suggested by arm in IRC.
Next step would be to test generate complete file including header.
For that i would remove what has to do with header in ``core/test_generate.py`` (for instance, https://github.com/pastly/simple-bw-scanner/blob/master/tests/core/test_generate.py#L101) and use the header class.
It can be done in that file, or move V3BWLine to ``lib/test_v3bwfile.py``.
@pastly what do you think?