### PR TITLE
Fix version, prepare for future release

### DIFF
--- a/sbws/util/parser.py
+++ b/sbws/util/parser.py
@@ -20,7 +20,7 @@ def create_parser():
     p = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     p.add_argument(
         '--version', action='version', help='sbws version',
-        version='%(prog)s {}'.format(__version__))
+        version='{}'.format(__version__))
     p.add_argument('--log-level',
                    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                    help='Override the sbws log level')

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def get_data_files():
 def find_version():
     with open(os.path.join("sbws", "__init__.py")) as fp:
         for line in fp:
-            if "SBWS_VERSION" in line.strip():
+            if "__version__" in line.strip():
                 version = line.split("=", 1)[1].strip().strip("'")
                 return version
 


### PR DESCRIPTION
``setup.py`` was using old global, source distribution would not automatically detect it.
``--version`` should return only the version, other tools as packaging ones depend on that, the name of the software itself is already returned in ``--help``.
When this PR is merged, it would be great to actually tag actually the commit as ``v0.1.0`` (better signed), so we have already a release (though not 1.0.0 yet) from which start packaging.
