### PR TITLE
Make RelayList stop overloading the CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make relay priority calculations take only ~5% of the time they used to (3s
   vs 60s) by using sets instead of lists when selecting non-Authority relays.
 (GH#204)
+- Make relay list refreshing take much less time by not allowing worker threads
+  to dogpile on the CPU. Before they would all start requesting descriptors
+from Tor at roughly the same time, causing us to overload our CPU core and make
+the process take unnecessarily long. Now we let one thread do the work so it
+can peg the CPU on its own and get the refresh done ASAP.
+(GH#205)
 
 ### Changed
 

--- a/sbws/core/scanner.py
+++ b/sbws/core/scanner.py
@@ -347,8 +347,8 @@ def run_speedtest(args, conf):
             'even lead to messed up results.', conf['tor']['control_socket'])
         time.sleep(15)
     assert stem_utils.is_controller_okay(controller)
-    cb = CB(args, conf, controller)
     rl = RelayList(args, conf, controller)
+    cb = CB(args, conf, controller, rl)
     rd = ResultDump(args, conf, end_event)
     rp = RelayPrioritizer(args, conf, rl, rd)
     destinations, error_msg = DestinationList.from_config(

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -2,7 +2,7 @@ from stem import CircuitExtensionFailed, InvalidRequest, ProtocolError, Timeout
 from stem import InvalidArguments
 import random
 import sbws.util.stem as stem_utils
-from .relaylist import Relay, RelayList
+from .relaylist import Relay
 import logging
 
 log = logging.getLogger(__name__)
@@ -39,10 +39,11 @@ class CircuitBuilder:
     them, but CircuitBuilder will keep track of existing circuits and close
     them when it is deleted.
     '''
-    def __init__(self, args, conf, controller, close_circuits_on_exit=True):
+    def __init__(self, args, conf, controller, relay_list,
+                 close_circuits_on_exit=True):
         self.controller = controller
         self.rng = random.SystemRandom()
-        self.relay_list = RelayList(args, conf, self.controller)
+        self.relay_list = relay_list
         self.built_circuits = set()
         self.close_circuits_on_exit = close_circuits_on_exit
         self.circuit_timeout = conf.getint('general', 'circuit_timeout')

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -168,16 +168,13 @@ class RelayList:
         return self._relays_with_flag(Flag.AUTHORITY)
 
     def random_relay(self):
-        relays = self.relays
-        return self.rng.choice(relays)
+        return self.rng.choice(self.relays)
 
     def _relays_with_flag(self, flag):
-        relays = self.relays
-        return [r for r in relays if flag in r.flags]
+        return [r for r in self.relays if flag in r.flags]
 
     def _relays_without_flag(self, flag):
-        relays = self.relays
-        return [r for r in relays if flag not in r.flags]
+        return [r for r in self.relays if flag not in r.flags]
 
     def _init_relays(self):
         c = self._controller

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -153,7 +153,6 @@ class RelayList:
                     log.debug('No we don\'t need to refresh our relays. '
                               'It was done by someone else.')
             log.debug('Giving back the lock for refreshing relays.')
-        assert not self._need_refresh()
         return self._relays
 
     @property

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -136,14 +136,23 @@ class RelayList:
         # See if we can get the list of relays without having to do a refresh,
         # which is expensive and blocks other threads
         if self._need_refresh():
+            log.debug('We need to refresh our list of relays. '
+                      'Going to wait for lock.')
             # Whelp we couldn't just get the list of relays because the list is
             # stale. Wait for the lock so we can refresh it.
             with self._refresh_lock:
+                log.debug('We got the lock. Now to see if we still '
+                          'need to refresh.')
                 # Now we have the lock ... but wait! Maybe someone else already
                 # did the refreshing. So check if it still needs refreshing. If
                 # not, we can do nothing.
                 if self._need_refresh():
+                    log.debug('Yup we need to refresh our relays. Doing so.')
                     self._refresh()
+                else:
+                    log.debug('No we don\'t need to refresh our relays. '
+                              'It was done by someone else.')
+            log.debug('Giving back the lock for refreshing relays.')
         assert not self._need_refresh()
         return self._relays
 


### PR DESCRIPTION
Make relay list refreshing take much less time by not allowing worker threads to dogpile on the CPU. Before they would all start requesting descriptors from Tor at roughly the same time, causing us to overload our CPU core and make the process take unnecessarily long. Now we let one thread do the work so it can peg the CPU on its own and get the refresh done ASAP.

Closes #205