### PR TITLE
Add write method back to V3BWFile clas

### DIFF
--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -4,7 +4,6 @@ from sbws.lib.resultdump import load_recent_results_in_datadir
 from argparse import ArgumentDefaultsHelpFormatter
 import os
 import logging
-from sbws.util.filelock import DirectoryLock
 from sbws.util.timestamp import now_fname
 
 log = logging.getLogger(__name__)
@@ -33,31 +32,6 @@ def gen_parser(sub):
                    'out, and we do so proportionally')
 
 
-def _write_v3bw_file(v3bwfile, output):
-    log.info('Writing v3bw file to %s', output)
-    out_dir = os.path.dirname(output)
-    out_link = os.path.join(out_dir, 'latest.v3bw')
-    if os.path.exists(out_link):
-        log.debug('Deleting existing symlink before creating a new one.')
-        os.remove(out_link)
-    # to keep test_generate.py working
-    if output != '/dev/stdout':
-        with DirectoryLock(out_dir):
-            with open(output, 'wt') as fd:
-                fd.write(str(v3bwfile.header))
-                for line in v3bwfile.bw_lines:
-                    fd.write(str(line))
-            output_basename = os.path.basename(output)
-            log.debug('Creating symlink from {} to {}.'
-                      .format(output_basename, out_link))
-            os.symlink(output_basename, out_link)
-    else:
-        with open(output, 'wt') as fd:
-            fd.write(str(v3bwfile.header))
-            for line in v3bwfile.bw_lines:
-                fd.write(str(line))
-
-
 def main(args, conf):
     if not is_initted(args.directory):
         fail_hard('Sbws isn\'t initialized.  Try sbws init')
@@ -83,5 +57,5 @@ def main(args, conf):
         return
     bw_file = V3BWFile.from_arg_results(args, conf, results)
     output = args.output or conf['paths']['v3bw_fname'].format(now_fname())
-    _write_v3bw_file(bw_file, output)
+    V3BWFile.write(output)
     log.info('Mean bandwidth per line: %f "KiB"', bw_file.avg_bw)

--- a/sbws/lib/v3bwfile.py
+++ b/sbws/lib/v3bwfile.py
@@ -76,14 +76,14 @@ def read_started_ts(conf):
     try:
         filepath = conf['paths']['started_filepath']
     except TypeError:
-        return ''
+        return None
     try:
         with FileLock(filepath):
             with open(filepath, 'r') as fd:
                 generator_started = fd.read()
     except FileNotFoundError as e:
         log.warn('File %s not found.%s', filepath, e)
-        return ''
+        return None
     return generator_started
 
 
@@ -229,7 +229,8 @@ class V3BWHeader(object):
         timestamp = str(latest_bandwidth)
         kwargs['latest_bandwidth'] = unixts_to_isodt_str(latest_bandwidth)
         kwargs['earliest_bandwidth'] = unixts_to_isodt_str(earliest_bandwidth)
-        kwargs['generator_started'] = generator_started
+        if generator_started is not None:
+            kwargs['generator_started'] = generator_started
         h = cls(timestamp, **kwargs)
         return h
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ from sbws.lib.resultdump import ResultError
 from sbws.lib.resultdump import ResultSuccess
 from sbws.lib.resultdump import Result
 from sbws.lib.resultdump import write_result_to_datadir
-from sbws.util.config import get_config
+from sbws.util.config import get_config, _get_default_config
 from sbws.util.parser import create_parser
 import sbws.core.init
 from tempfile import TemporaryDirectory
@@ -48,6 +48,39 @@ def datadir(request):
             with self.open(name, "r") as f:
                 return f.readlines()
     return D(request.fspath.dirpath("data"))
+
+
+@pytest.fixture
+def tmpdir(tmpdir_factory, request):
+    """Create a tmp dir for the tests"""
+    base = str(hash(request.node.nodeid))[:3]
+    bn = tmpdir_factory.mktemp(base)
+    return bn
+
+
+@pytest.fixture
+def tmpdir_sbwshome(tmpdir):
+    """Create .sbws inside of the tests tmp dir"""
+    home = tmpdir.join('.sbws')
+    os.makedirs(home.strpath, exist_ok=True)
+    return home
+
+
+@pytest.fixture()
+def unittest_args(tmpdir_sbwshome, parser):
+    """Args with sbws home in the tests tmp dir"""
+    return _PseudoArguments(directory=tmpdir_sbwshome.strpath,
+                            output=tmpdir_sbwshome.strpath,
+                            scale=False)
+
+
+@pytest.fixture()
+def unittest_conf(tmpdir_sbwshome):
+    """Default configuration with sbws home in the tmp test dir"""
+    conf = _get_default_config()
+    conf['paths']['sbwshome'] = tmpdir_sbwshome.strpath
+    conf['paths']['started_filepath'] = ""
+    return conf
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
Fixes #197

@pastly, with the introduced fixtures we could rewrite empty_sbws and others in the future, unless you have other suggestions.