### PR TITLE
Check that there are exits

### DIFF
--- a/sbws/lib/destination.py
+++ b/sbws/lib/destination.py
@@ -186,6 +186,9 @@ class DestinationList:
             possible_exits = sorted(
                 possible_exits, key=lambda e: e.bandwidth, reverse=True)
             exits = possible_exits[0:num_keep]
+            if len(exits) < 1:
+                log.warning("There are no exits to perform usability tests.")
+                continue
             # Try three times to build a circuit to test this destination
             circ_id = None
             for _ in range(0, 3):


### PR DESCRIPTION
to perform usability tests. This will avoid raising IndexError
when choosing an exit.

Fixes #211