### PR TITLE
Require python version from 3.4.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     },
     data_files=get_data_files(),
     keywords='',
-    python_requires='>=3.4',
+    python_requires='>=3.4.5',
     # test_suite='test',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Since version 3.4.2 gives error on install_layout and it is not
the default in stable OS distributions

Fixes #194