### PR TITLE
Issue192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Measure relays that have both Exit and BadExit as non-exits, which is how
   clients would use them. (GH#217)
 
+### Changed
+
+- Remove is_controller_ok. Instead catch possible controller exceptions and 
+log them
+
 
 ## [0.5.0] - 2018-06-26
 
@@ -62,8 +67,6 @@ generated ones are kept. A `latest.v3bw` symlink is updated. (GH#179 GHPR#190)
 - Code refactoring in the v3bw classes and generation area
 - Replace v3bw-into-xy bash script with python script to handle a more complex
   v3bw file format (GH#182)
-- Remove is_controller_ok. Instead catch possible controller exceptions and 
- log them
 
 ## [0.4.1] - 2018-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ generated ones are kept. A `latest.v3bw` symlink is updated. (GH#179 GHPR#190)
 - Code refactoring in the v3bw classes and generation area
 - Replace v3bw-into-xy bash script with python script to handle a more complex
   v3bw file format (GH#182)
+- Remove is_controller_ok. Instead catch possible controller exceptions and 
+ log them
 
 ## [0.4.1] - 2018-06-14
 

--- a/sbws/core/scanner.py
+++ b/sbws/core/scanner.py
@@ -347,7 +347,6 @@ def run_speedtest(args, conf):
             'exists for sbws developers. It is expected to be broken and may '
             'even lead to messed up results.', conf['tor']['control_socket'])
         time.sleep(15)
-    assert stem_utils.is_controller_okay(controller)
     rl = RelayList(args, conf, controller)
     cb = CB(args, conf, controller, rl)
     rd = ResultDump(args, conf, end_event)

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -27,7 +27,6 @@ class CircuitBuilder:
     ''' The CircuitBuilder interface.
 
     Subclasses must implement their own build_circuit() function.
-    Subclasses probably shouldn't implement their own get_circuit_path().
     Subclasses may keep additional state if they'd find it helpful.
 
     The primary way to use a CircuitBuilder of any type is to simply create it

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -1,5 +1,5 @@
 from stem import CircuitExtensionFailed, InvalidRequest, ProtocolError, Timeout
-from stem import InvalidArguments
+from stem import InvalidArguments, ControllerError
 import random
 from .relaylist import Relay
 import logging
@@ -64,7 +64,7 @@ class CircuitBuilder:
             except InvalidArguments:
                 pass
             self.built_circuits.discard(circ_id)
-        except Exception as e:
+        except (ControllerError, ValueError) as e:
             log.exception("Error trying to get circuit to close it: %s.", e)
 
     def _build_circuit_impl(self, path):

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -61,7 +61,7 @@ class CircuitBuilder:
             c.get_circuit(circ_id, default=None)
             try:
                 c.close_circuit(circ_id)
-            except InvalidArguments:
+            except (InvalidArguments, InvalidRequest):
                 pass
             self.built_circuits.discard(circ_id)
         except (ControllerError, ValueError) as e:

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -82,9 +82,6 @@ class CircuitBuilder:
                     ProtocolError, Timeout) as e:
                 log.warning(e)
                 continue
-            except Exception as e:
-                log.exception("Exception trying to build circuit: %s.", e)
-                continue
             else:
                 return circ_id
         return None

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -56,16 +56,6 @@ class CircuitBuilder:
         its (str) ID. If it cannot be built, it should return None. '''
         raise NotImplementedError()
 
-    def get_circuit_path(self, circ_id):
-        c = self.controller
-        try:
-            circ = c.get_circuit(circ_id, default=None)
-        except Exception as e:
-            log.exception("Exception trying to get circuit: %s.", e)
-        else:
-            return [relay[0] for relay in circ.path]
-        return None
-
     def close_circuit(self, circ_id):
         c = self.controller
         try:

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -95,7 +95,7 @@ class CircuitBuilder:
                 c.get_circuit(circ_id, default=None)
                 try:
                     c.close_circuit(circ_id)
-                except InvalidArguments:
+                except (InvalidArguments, InvalidRequest):
                     pass
             except (ControllerError, InvalidArguments) as e:
                 log.exception("Exception trying to get circuit to delete: %s",

--- a/sbws/lib/circuitbuilder.py
+++ b/sbws/lib/circuitbuilder.py
@@ -97,7 +97,7 @@ class CircuitBuilder:
                     c.close_circuit(circ_id)
                 except InvalidArguments:
                     pass
-            except Exception as e:
+            except (ControllerError, InvalidArguments) as e:
                 log.exception("Exception trying to get circuit to delete: %s",
                               e)
         self.built_circuits.clear()

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -39,7 +39,7 @@ class Relay:
         else:
             try:
                 self._desc = cont.get_server_descriptor(fp, default=None)
-            except Exception as e:
+            except (DescriptorUnavailable, ControllerError) as e:
                 log.exception("Exception trying to get desc %s", e)
 
     def _from_desc(self, attr):

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -32,6 +32,7 @@ class Relay:
                 self._ns = cont.get_network_status(fp, default=None)
             except Exception as e:
                 log.exception("Exception trying to get ns %s", e)
+                self._ns = None
         if desc is not None:
             assert isinstance(desc, ServerDescriptor)
             self._desc = desc

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -40,7 +40,7 @@ class Relay:
             try:
                 self._desc = cont.get_server_descriptor(fp, default=None)
             except Exception as e:
-                log.exception("Exception trying to get ns %s", e)
+                log.exception("Exception trying to get desc %s", e)
 
     def _from_desc(self, attr):
         if not self._desc:

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -1,6 +1,6 @@
 from stem.descriptor.router_status_entry import RouterStatusEntryV3
 from stem.descriptor.server_descriptor import ServerDescriptor
-from stem import Flag
+from stem import Flag, DescriptorUnavailable, ControllerError
 from stem.util.connection import is_valid_ipv4_address
 from stem.util.connection import is_valid_ipv6_address
 import random
@@ -30,7 +30,7 @@ class Relay:
         else:
             try:
                 self._ns = cont.get_network_status(fp, default=None)
-            except Exception as e:
+            except (DescriptorUnavailable, ControllerError) as e:
                 log.exception("Exception trying to get ns %s", e)
                 self._ns = None
         if desc is not None:

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -198,7 +198,7 @@ class RelayList:
         try:
             relays = [Relay(ns.fingerprint, c, ns=ns)
                       for ns in c.get_network_statuses()]
-        except Exception as e:
+        except ControllerError as e:
             log.exception("Exception trying to init relays %s", e)
             return []
         return relays

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -245,7 +245,7 @@ def circuit_str(controller, circ_id):
         log.warning('Circuit %s no longer seems to exist so can\'t return '
                     'a valid circuit string for it: %s', circ_id, e)
         return None
-    except Exception as e:
+    except ControllerError as e:
         log.exception("Exception trying to get circuit string %s", e)
         return None
     return '[' +\

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -1,6 +1,7 @@
 from stem.control import (Controller, Listener)
 from stem import (SocketError, InvalidRequest, UnsatisfiableRequest,
-                  OperationFailed)
+                  OperationFailed, ControllerError, InvalidArguments,
+                  ProtocolError)
 from stem.connection import IncorrectSocketType
 import stem.process
 from configparser import ConfigParser
@@ -79,7 +80,7 @@ def init_controller(port=None, path=None, set_custom_stream_settings=True):
 def is_bootstrapped(c):
     try:
         line = c.get_info('status/bootstrap-phase')
-    except Exception as e:
+    except (ControllerError, InvalidArguments, ProtocolError) as e:
         log.exception("Error trying to check bootstrap phase %s", e)
         return False
     state, _, progress, *_ = line.split()

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -211,7 +211,7 @@ def get_socks_info(controller):
     try:
         socks_ports = controller.get_listeners(Listener.SOCKS)
         return socks_ports[0]
-    except Exception as e:
+    except ControllerError as e:
         log.exception("Exception trying to get socks info: %e.", e)
         exit(1)
 

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -40,7 +40,7 @@ def attach_stream_to_circuit_listener(controller, circ_id):
 def add_event_listener(controller, func, event):
     try:
         controller.add_event_listener(func, event)
-    except Exception as e:
+    except ProtocolError as e:
         log.exception("Exception trying to add event listener %s", e)
 
 

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -1,5 +1,6 @@
 from stem.control import (Controller, Listener)
-from stem import (SocketError, InvalidRequest, UnsatisfiableRequest)
+from stem import (SocketError, InvalidRequest, UnsatisfiableRequest,
+                  OperationFailed)
 from stem.connection import IncorrectSocketType
 import stem.process
 from configparser import ConfigParser
@@ -27,7 +28,7 @@ def attach_stream_to_circuit_listener(controller, circ_id):
             except (UnsatisfiableRequest, InvalidRequest) as e:
                 log.warning('Couldn\'t attach stream to circ %s: %s',
                             circ_id, e)
-            except Exception as e:
+            except OperationFailed as e:
                 log.exception("Error attaching stream %s to circ %s: %s",
                               st.id, circ_id, e)
         else:

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -181,8 +181,11 @@ def launch_tor(conf):
                 existing_val.append(value)
                 torrc.update({key: existing_val})
     # Finally launch Tor
-    stem.process.launch_tor_with_config(
-        torrc, init_msg_handler=log.debug, take_ownership=True)
+    try:
+        stem.process.launch_tor_with_config(
+            torrc, init_msg_handler=log.debug, take_ownership=True)
+    except Exception as e:
+        fail_hard('Error trying to launch tor: %s', e)
     # And return a controller to it
     cont = _init_controller_socket(conf['tor']['control_socket'])
     # Because we build things by hand and can't set these before Tor bootstraps

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -195,7 +195,7 @@ def launch_tor(conf):
     try:
         cont.set_conf('__DisablePredictedCircuits', '1')
         cont.set_conf('__LeaveStreamsUnattached', '1')
-    except Exception as e:
+    except (ControllerError, InvalidArguments, InvalidRequest) as e:
         log.exception("Error trying to launch tor: %s. "
                       "Maybe the tor directory is being used by other "
                       "sbws instance?", e)

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -192,14 +192,15 @@ def launch_tor(conf):
     # And return a controller to it
     cont = _init_controller_socket(conf['tor']['control_socket'])
     # Because we build things by hand and can't set these before Tor bootstraps
-    cont.set_conf('__DisablePredictedCircuits', '1')
-    cont.set_conf('__LeaveStreamsUnattached', '1')
     try:
-        log.info('Started and connected to Tor %s via %s', cont.get_version(),
-                 conf['tor']['control_socket'])
-        return cont
+        cont.set_conf('__DisablePredictedCircuits', '1')
+        cont.set_conf('__LeaveStreamsUnattached', '1')
     except Exception as e:
         log.exception("Exception trying to launch tor %s", e)
+        exit(1)
+    log.info('Started and connected to Tor %s via %s', cont.get_version(),
+             conf['tor']['control_socket'])
+    return cont
 
 
 def get_socks_info(controller):

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -196,7 +196,9 @@ def launch_tor(conf):
         cont.set_conf('__DisablePredictedCircuits', '1')
         cont.set_conf('__LeaveStreamsUnattached', '1')
     except Exception as e:
-        log.exception("Exception trying to launch tor %s", e)
+        log.exception("Error trying to launch tor: %s. "
+                      "Maybe the tor directory is being used by other "
+                      "sbws instance?", e)
         exit(1)
     log.info('Started and connected to Tor %s via %s', cont.get_version(),
              conf['tor']['control_socket'])

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -28,7 +28,8 @@ def attach_stream_to_circuit_listener(controller, circ_id):
                 log.warning('Couldn\'t attach stream to circ %s: %s',
                             circ_id, e)
             except Exception as e:
-                log.exception("Exception trying to get ns %s", e)
+                log.exception("Error attaching stream %s to circ %s: %s",
+                              st.id, circ_id, e)
         else:
             pass
     return closure_stream_event_listener

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -80,7 +80,7 @@ def is_bootstrapped(c):
     try:
         line = c.get_info('status/bootstrap-phase')
     except Exception as e:
-        log.exception("Exception bootstrapping %s", e)
+        log.exception("Error trying to check bootstrap phase %s", e)
         return False
     state, _, progress, *_ = line.split()
     progress = int(progress.split('=')[1])

--- a/sbws/util/stem.py
+++ b/sbws/util/stem.py
@@ -47,7 +47,7 @@ def add_event_listener(controller, func, event):
 def remove_event_listener(controller, func):
     try:
         controller.remove_event_listener(func)
-    except Exception as e:
+    except ProtocolError as e:
         log.exception("Exception trying to remove event %s", e)
 
 

--- a/tests/integration/util/test_stem.py
+++ b/tests/integration/util/test_stem.py
@@ -3,5 +3,4 @@ import sbws.util.stem as stem_utils
 
 def test_launch_and_okay(persistent_launch_tor):
     cont = persistent_launch_tor
-    assert stem_utils.is_controller_okay(cont)
     assert stem_utils.is_bootstrapped(cont)


### PR DESCRIPTION
Fixes #192.
It's catching all possible controller exceptions and logging them. 
If/when we know more details about why they happen, we might want to catch only those and do something different.
In some cases we might want to return different to what it's now returned.
This solution is almost the same as just letting the Exception raise.
It seems that we could also use ``add_status_listener`` [0] to the controller, though i'm not sure now which functions we should call in the different situations.

[0] https://stem.torproject.org/api/control.html#stem.control.BaseController.add_status_listener