### PR TITLE
Log sbws version info line on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Log line on start up with sbws version, platform info, and library versions
+(trac#26751)
+
 ## [0.6.0] - 2018-07-11
 
 **Important changes**:

--- a/sbws/sbws.py
+++ b/sbws/sbws.py
@@ -7,6 +7,10 @@ from sbws.util.config import get_config
 from sbws.util.config import validate_config
 from sbws.util.config import configure_logging
 from sbws.util.parser import create_parser
+from sbws import __version__ as SBWS_VERSION
+from stem import __version__ as STEM_VERSION
+from requests.__version__ import __version__ as REQ_VERSION
+import platform
 import logging
 
 log = logging.getLogger(__name__)
@@ -16,6 +20,13 @@ def _adjust_log_level(args, conf):
     if not args.log_level:
         return
     conf['logger_sbws']['level'] = args.log_level
+
+
+def _get_startup_line():
+    py_ver = platform.python_version()
+    py_plat = platform.platform()
+    return 'sbws %s with python %s on %s, stem %s, and requests %s' % \
+        (SBWS_VERSION, py_ver, py_plat, STEM_VERSION, REQ_VERSION)
 
 
 def main():
@@ -47,6 +58,7 @@ def main():
         if args.command not in known_commands:
             parser.print_help()
         else:
+            log.info(_get_startup_line())
             comm = known_commands[args.command]
             exit(comm['f'](*comm['a'], **comm['kw']))
     except KeyboardInterrupt:


### PR DESCRIPTION
Produces a line such as the following.

`[2018-07-11 11:27:35,464] [sbws.sbws] [INFO] sbws 0.6.1-dev with python 3.6.5 on Darwin-15.6.0-x86_64-i386-64bit, stem 1.6.0-dev, and requests 2.18.4`