### PR TITLE
Stop deleting the latest.v3bw symlink. Instead, do an atomic rename.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Log line on start up with sbws version, platform info, and library versions
 (trac#26751)
 
+### Fixed
+
+- Stop deleting the latest.v3bw symlink. Instead, do an atomic rename.
+  (#26740)
+
 ### Changed
 
-- Document at which times should v3bw files be generated (#26740)
 - Remove test data v3bw file and generate it from the same test. (#26736)
 
 ## [0.6.0] - 2018-07-11

--- a/sbws/config.default.ini
+++ b/sbws/config.default.ini
@@ -1,6 +1,8 @@
 [paths]
 datadir = ${sbws_home}/datadir
 v3bw_dname = ${sbws_home}/v3bw
+# The latest bandwidth file is atomically symlinked to
+# V3BandwidthsFile ${v3bw_dname}/latest.v3bw
 v3bw_fname = ${v3bw_dname}/{}.v3bw
 started_filepath = ${sbws_home}/started_at
 log_dname = ${sbws_home}/log

--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -12,12 +12,13 @@ log = logging.getLogger(__name__)
 def gen_parser(sub):
     d = 'Generate a v3bw file based on recent results. A v3bw file is the '\
         'file Tor directory authorities want to read and base their '\
-        'bandwidth votes on.' \
-        'This file should be generated every hour at any minute, except ' \
-        'between 45 and 55 minutes past the hour because Tor read this file '\
-        ' at minute 50 and except ' \
-        'between 15 and 25 minutes past the hour because Tor read this file '\
-        ' at minute 20 during a consensus failure.'
+        'bandwidth votes on. '\
+        'To avoid inconsistent reads, configure tor with '\
+        '"V3BandwidthsFile /path/to/latest.v3bw". '\
+        '(latest.v3bw is an atomically created symlink in the same '\
+        'directory as output.) '\
+        'If the file is transferred to another host, it should be written to '\
+        'a temporary path, then renamed to the V3BandwidthsFile path.'
     p = sub.add_parser('generate', description=d,
                        formatter_class=ArgumentDefaultsHelpFormatter)
     p.add_argument('--output', default=None, type=str,


### PR DESCRIPTION
Also:
* document the location of latest.v3bw
* document the atomic creation of latest.v3bw
* explain how to atomically create latest.v3bw when transferring it to
  another host

Closes tor trac 26740.

For an explanation of the code changes, see the comments, or the second (atomic) answer on:
https://stackoverflow.com/questions/8299386/modifying-a-symlink-in-python